### PR TITLE
Extension method to allow specification of pipeline stage for middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build/
 bld/
 [Bb]in/
 [Oo]bj/
+.vs/*
 
 # Roslyn cache directories
 *.ide/
@@ -181,3 +182,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+*.ncrunchproject
+*.ncrunchsolution

--- a/Kentor.OwinCookieSaver.Tests/KentorOwinCookieSaverExtensionsTests.cs
+++ b/Kentor.OwinCookieSaver.Tests/KentorOwinCookieSaverExtensionsTests.cs
@@ -19,5 +19,15 @@ namespace Kentor.OwinCookieSaver.Tests
 
             app.Received().Use(typeof(KentorOwinCookieSaverMiddleware));
         }
+
+        [TestMethod]
+        public void KentorOwinCookieSaverExtensions_Use_With_Stage_RegistersMiddleware()
+        {
+            var app = Substitute.For<IAppBuilder>();
+
+            app.UseKentorOwinCookieSaver(PipelineStage.Authenticate);
+
+            app.Received().Use(typeof(KentorOwinCookieSaverMiddleware));
+        }
     }
 }

--- a/Kentor.OwinCookieSaver/KentorOwinCookieSaverExtensions.cs
+++ b/Kentor.OwinCookieSaver/KentorOwinCookieSaverExtensions.cs
@@ -1,10 +1,5 @@
 ﻿using Kentor.OwinCookieSaver;
-using Owin;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Owin.Extensions;
 
 namespace Owin
 {
@@ -22,6 +17,21 @@ namespace Owin
         public static IAppBuilder UseKentorOwinCookieSaver(this IAppBuilder app)
         {
             app.Use(typeof(KentorOwinCookieSaverMiddleware));
+
+            return app;
+        }
+
+        /// <summary>
+        /// Enables the Kentor Owin Cookie Saver middleware, that prevents owin
+        /// auth cookies from disappearing. Add above any cookie middleware.
+        /// </summary>
+        /// <param name="app">Owin app</param>
+        /// <param name="stage"> stage in the integrated pipeline prior middleware should run</param>
+        /// <returns>Owin app</returns>
+        public static IAppBuilder UseKentorOwinCookieSaver(this IAppBuilder app, PipelineStage stage)
+        {
+            app.Use(typeof(KentorOwinCookieSaverMiddleware));
+            app.UseStageMarker(stage);
 
             return app;
         }

--- a/SampleWebApp/App_Start/Startup.Auth.cs
+++ b/SampleWebApp/App_Start/Startup.Auth.cs
@@ -8,6 +8,7 @@ using Microsoft.Owin.Security.Cookies;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Kentor.OwinCookieSaver;
+using Microsoft.Owin.Extensions;
 
 [assembly: OwinStartup(typeof(SampleWebApp.App_Start.Startup))]
 
@@ -37,6 +38,7 @@ namespace SampleWebApp.App_Start
         public void Configuration(IAppBuilder app)
         {
             app.Use(typeof(ConditionalMiddlewareInvoker));
+            app.UseStageMarker(PipelineStage.Authenticate);
 
             app.UseCookieAuthentication(new CookieAuthenticationOptions());
 


### PR DESCRIPTION
We are using bearer authentication with cookies for SignalR, and it's middleware moves itself earlier in the pipeline than the cookie saver middleware, so we would see the same issue with authentication for SignalR that we were (before cookie saver) on our authenticated ASP pages.

So, I required the ability to move the cookie saver middleware "above" SignalR in the pipeline. Pretty simple extension that I am using locally, but I thought I would contribute back since we have been getting great value from the 'saver'.